### PR TITLE
Christian/java fx UI tests update 2

### DIFF
--- a/src/test/java/JavaFxTest.java
+++ b/src/test/java/JavaFxTest.java
@@ -115,6 +115,7 @@ public class JavaFxTest {
         assertNotNull(robot.lookup("View Exercises").queryAs(Button.class), "View Exercises button should exist");
         assertNotNull(robot.lookup("Add Exercise").queryAs(Button.class), "Add Exercise button should exist");
         assertNotNull(robot.lookup("View History").queryAs(Button.class), "View History button should exist");
+        assertNotNull(robot.lookup("Delete Workout").queryAs(Button.class), "Delete Workout button should exist");
         assertNotNull(robot.lookup("Sign Out").queryAs(Button.class), "Sign Out button should exist");
     }
 
@@ -391,5 +392,18 @@ public class JavaFxTest {
         Label mainLabel = robot.lookup("Welcome, otter").queryAs(Label.class);
         assertNotNull(mainLabel, "Should return to MainView after clicking Cancel Button");
         assertTrue(mainLabel.isVisible(), "Welcome label should be visible after cancel");
+    }
+
+    @Test
+    void deleteWorkoutOpens(FxRobot robot){
+        //Login
+        loginAsOtter(robot);
+        //Click on Delete Workout
+        robot.clickOn("Delete Workout");
+        robot.sleep(400);
+        //Delete Workout title should be visible
+        Label title = robot.lookup("Delete Workout").queryAs(Label.class);
+        assertNotNull(title, "Delete Workout title label should exist after clicking Delete Workout");
+        assertTrue(title.isVisible(), "Delete Workout title should be visible");
     }
 }

--- a/src/test/java/JavaFxTest.java
+++ b/src/test/java/JavaFxTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @version 0.3.0 : JA : Updated after altering MainView
  * @version 0.4.0 : CH : Updated for new MainView, ViewHistory scene, and CreateUserView email/cancel fields
  * @version 0.5.0 : CH : Updated for adding ViewExercises and AddExercise
+ * @version 0.6.0 : CH : Updated for adding LogWorkoutView and DeleteWorkoutView
  */
 @ExtendWith(ApplicationExtension.class)
 public class JavaFxTest {
@@ -418,5 +419,21 @@ public class JavaFxTest {
         ComboBox<?> workoutCombo = robot.lookup(".combo-box").queryAs(ComboBox.class);
         assertNotNull(workoutCombo, "Workout ComboBox should exist on Delete Workout");
         assertFalse(workoutCombo.getItems().isEmpty(), "Workout ComboBox should contain at least one entry");
+    }
+
+    @Test
+    void deleteWorkoutCancelButton(FxRobot robot){
+        //Login
+        loginAsOtter(robot);
+        //Click on Delete Workout
+        robot.clickOn("Delete Workout");
+        robot.sleep(400);
+        //Click on the Cancel Button
+        robot.clickOn("Cancel");
+        robot.sleep(400);
+        //Should be back on MainView after clicking cancel
+        Label mainLabel = robot.lookup("Welcome, otter").queryAs(Label.class);
+        assertNotNull(mainLabel, "Should return to MainView after clicking Cancel Button");
+        assertTrue(mainLabel.isVisible(), "Welcome label should be visible after cancel");
     }
 }

--- a/src/test/java/JavaFxTest.java
+++ b/src/test/java/JavaFxTest.java
@@ -17,6 +17,7 @@ import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
 import ui.login.CreateUserView;
 import ui.login.LoginView;
+import ui.main.ViewExercises;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -29,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @version 0.2.0 : RC : Updated after changing the Login view
  * @version 0.3.0 : JA : Updated after altering MainView
  * @version 0.4.0 : CH : Updated for new MainView, ViewHistory scene, and CreateUserView email/cancel fields
+ * @version 0.5.0 : CH : Updated for adding ViewExercises and AddExercise
  */
 @ExtendWith(ApplicationExtension.class)
 public class JavaFxTest {
@@ -221,6 +223,48 @@ public class JavaFxTest {
         //Check for MainView after Login
         Label mainLabel = robot.lookup("Welcome, newUser").queryAs(Label.class);
         assertNotNull(mainLabel, "MainView should be showing after successful Login");
+        assertTrue(mainLabel.isVisible());
+    }
+
+    @Test
+    void viewExercisesOpens(FxRobot robot){
+        //Login
+        loginAsOtter(robot);
+        //Click View Exercises button
+        robot.clickOn("View Exercises");
+        robot.sleep(1000);
+        //Check for Title after Scene change
+        Label title = robot.lookup("Exercises").queryAs(Label.class);
+        assertNotNull(title, "Exercises title label should exist");
+        assertTrue(title.isVisible(), "Exercises title should be visible");
+    }
+
+    @Test
+    void viewExercisesListShows(FxRobot robot){
+        //Login
+        loginAsOtter(robot);
+        //Click on View Exercises button
+        robot.clickOn("View Exercises");
+        robot.sleep(1000);
+        //Check the list exists and has the test data
+        ListView<?> list = robot.lookup(".list-view").queryAs(ListView.class);
+        assertNotNull(list, "Exercise ListView should exist");
+        assertFalse(list.getItems().isEmpty(), "Exercise list should contain at least one entry from test data");
+    }
+
+    @Test
+    void viewExercisesBackButton(FxRobot robot){
+        //Login
+        loginAsOtter(robot);
+        //Click on View Exercises button
+        robot.clickOn("View Exercises");
+        robot.sleep(1000);
+        //Click on Back button
+        robot.clickOn("Back");
+        robot.sleep(1000);
+        //Should be back on MainView
+        Label mainLabel = robot.lookup("Welcome, otter").queryAs(Label.class);
+        assertNotNull(mainLabel, "Should return to MainView after clicking Back button in ViewExercises");
         assertTrue(mainLabel.isVisible());
     }
 }

--- a/src/test/java/JavaFxTest.java
+++ b/src/test/java/JavaFxTest.java
@@ -361,5 +361,35 @@ public class JavaFxTest {
         //Should be back on MainView after saving new exercise
         Label mainLabel = robot.lookup("Welcome, otter").queryAs(Label.class);
         assertNotNull(mainLabel, "Should return to MainView after clicking Save button in AddExercise");
+        assertTrue(mainLabel.isVisible(), "Welcome label should be visible after cancel");
+    }
+
+    @Test
+    void logWorkoutOpens(FxRobot robot){
+        //Login
+        loginAsOtter(robot);
+        //Click on Log Workout
+        robot.clickOn("Log Workout");
+        robot.sleep(400);
+        //Log workout title should be visible on the after clicking
+        Label title = robot.lookup("Log Workout").queryAs(Label.class);
+        assertNotNull(title, "Log Workout title label should exist after clicking Log Workout");
+        assertTrue(title.isVisible(), "Log Workout title should be visible");
+    }
+
+    @Test
+    void logWorkoutCancelButton(FxRobot robot){
+        //Login
+        loginAsOtter(robot);
+        //Click on Log Workout
+        robot.clickOn("Log Workout");
+        robot.sleep(400);
+        //Click on Cancel Button
+        robot.clickOn("Cancel");
+        robot.sleep(400);
+        //Should be back on MainView after clicking cancel
+        Label mainLabel = robot.lookup("Welcome, otter").queryAs(Label.class);
+        assertNotNull(mainLabel, "Should return to MainView after clicking Cancel Button");
+        assertTrue(mainLabel.isVisible(), "Welcome label should be visible after cancel");
     }
 }

--- a/src/test/java/JavaFxTest.java
+++ b/src/test/java/JavaFxTest.java
@@ -69,8 +69,6 @@ public class JavaFxTest {
 
     @Test
     void loginButtonFails(FxRobot robot){
-        //Pause to show testing process
-        robot.sleep(1000);
         //Find and populate username and password
         robot.clickOn("#" + LoginView.usernameField).write("oops");
         robot.clickOn("#" + LoginView.passwordField).write("oops");
@@ -78,7 +76,7 @@ public class JavaFxTest {
         Button loginButton = robot.lookup("#" + LoginView.loginButton).queryAs(Button.class);
         robot.clickOn(loginButton);
         //Pause to show the testing process
-        robot.sleep(1000);
+        robot.sleep(400);
         //Invalid login should show here
         Label message = robot.lookup("#" + LoginView.messageField).queryAs(Label.class);
         assertNotNull(message);
@@ -88,14 +86,12 @@ public class JavaFxTest {
 
     @Test
     void loginButtonLogsIn(FxRobot robot){
-        // Pause to show testing process
-        robot.sleep(1000);
         // Enter login credentials
         robot.clickOn("#" + LoginView.usernameField).write("otter");
         robot.clickOn("#" + LoginView.passwordField).write("otter");
         Button loginButton = robot.lookup("#" + LoginView.loginButton).queryAs(Button.class);
         robot.clickOn(loginButton);
-        robot.sleep(1000);
+        robot.sleep(400);
         assertTrue(testStage.isShowing(), "Main stage should still be showing after login");
         // Check for welcome label
         Label welcomeLabel = robot.lookup("Welcome, otter").queryAs(Label.class);
@@ -107,7 +103,7 @@ public class JavaFxTest {
         robot.clickOn("#" + LoginView.usernameField).write("otter");
         robot.clickOn("#" + LoginView.passwordField).write("otter");
         robot.clickOn("#" + LoginView.loginButton);
-        robot.sleep(1000);
+        robot.sleep(400);
     }
 
     @Test
@@ -128,7 +124,7 @@ public class JavaFxTest {
         loginAsOtter(robot);
         //Sign out
         robot.clickOn("Sign Out");
-        robot.sleep(1000);
+        robot.sleep(400);
         //Check for Login Scene after Sign Out
         Label loginLabel = robot.lookup("#" + LoginView.loginTitle).queryAs(Label.class);
         assertNotNull(loginLabel, "Login title should reappear after sign out");
@@ -141,7 +137,7 @@ public class JavaFxTest {
         loginAsOtter(robot);
         //View History button press
         robot.clickOn("View History");
-        robot.sleep(1000);
+        robot.sleep(400);
         //Check Title
         Label title = robot.lookup("Workout History").queryAs(Label.class);
         assertNotNull(title, "Workout History title label should exist");
@@ -158,10 +154,10 @@ public class JavaFxTest {
         loginAsOtter(robot);
         //View History button press
         robot.clickOn("View History");
-        robot.sleep(1000);
+        robot.sleep(400);
         //Back button click
         robot.clickOn("Back");
-        robot.sleep(1000);
+        robot.sleep(400);
         //Check to be back on MainView
         Label mainLabel = robot.lookup("Welcome, otter").queryAs(Label.class);
         assertNotNull(mainLabel, "Should be back to MainView after clicking Back");
@@ -172,7 +168,7 @@ public class JavaFxTest {
     void createUserSceneEmail(FxRobot robot){
         //Start clicking Create Account
         robot.clickOn("Create Account");
-        robot.sleep(500);
+        robot.sleep(400);
         //Checking Email Field
         TextField emailField = robot.lookup("#" + CreateUserView.emailField).queryAs(TextField.class);
         assertNotNull(emailField, "Email field should exist on CreateUser scene");
@@ -183,10 +179,10 @@ public class JavaFxTest {
     void createUserCancelReturns(FxRobot robot){
         //Click on Create Account
         robot.clickOn("Create Account");
-        robot.sleep(1000);
+        robot.sleep(400);
         //Click on Cancel
         robot.clickOn("Cancel");
-        robot.sleep(1000);
+        robot.sleep(400);
         //Check for Login Scene
         Label loginLabel = robot.lookup("#" + LoginView.loginTitle).queryAs(Label.class);
         assertNotNull(loginLabel, "Cancel should return to the Login Scene");
@@ -197,10 +193,10 @@ public class JavaFxTest {
     void createUserInvalidInput(FxRobot robot){
         //Click on Create Account
         robot.clickOn("Create Account");
-        robot.sleep(1000);
+        robot.sleep(400);
         //Fields Blank and try to save for the invalid input
         robot.clickOn("Save");
-        robot.sleep(1000);
+        robot.sleep(400);
         //Check for error message
         Label message = robot.lookup("#" + CreateUserView.messageField).queryAs(Label.class);
         assertNotNull(message);
@@ -211,7 +207,7 @@ public class JavaFxTest {
     void createUserSuccess(FxRobot robot){
         //Click on Create Account
         robot.clickOn("Create Account");
-        robot.sleep(500);
+        robot.sleep(400);
         //Input new test user
         robot.clickOn("#" + CreateUserView.usernameField).write("newUser");
         robot.clickOn("#" + CreateUserView.emailField).write("newUser@test.com");
@@ -231,7 +227,7 @@ public class JavaFxTest {
         loginAsOtter(robot);
         //Click View Exercises button
         robot.clickOn("View Exercises");
-        robot.sleep(1000);
+        robot.sleep(400);
         //Check for Title after Scene change
         Label title = robot.lookup("Exercises").queryAs(Label.class);
         assertNotNull(title, "Exercises title label should exist");
@@ -244,7 +240,7 @@ public class JavaFxTest {
         loginAsOtter(robot);
         //Click on View Exercises button
         robot.clickOn("View Exercises");
-        robot.sleep(1000);
+        robot.sleep(400);
         //Check the list exists and has the test data
         ListView<?> list = robot.lookup(".list-view").queryAs(ListView.class);
         assertNotNull(list, "Exercise ListView should exist");
@@ -257,10 +253,10 @@ public class JavaFxTest {
         loginAsOtter(robot);
         //Click on View Exercises button
         robot.clickOn("View Exercises");
-        robot.sleep(1000);
+        robot.sleep(400);
         //Click on Back button
         robot.clickOn("Back");
-        robot.sleep(1000);
+        robot.sleep(400);
         //Should be back on MainView
         Label mainLabel = robot.lookup("Welcome, otter").queryAs(Label.class);
         assertNotNull(mainLabel, "Should return to MainView after clicking Back button in ViewExercises");
@@ -273,7 +269,7 @@ public class JavaFxTest {
         loginAsOtter(robot);
         //Click on Add Exercise
         robot.clickOn("Add Exercise");
-        robot.sleep(1000);
+        robot.sleep(400);
         //Check for Title after Scene change
         Label title = robot.lookup("Add Exercise").queryAs(Label.class);
         assertNotNull(title, "Add Exercise title label should exist");
@@ -286,7 +282,7 @@ public class JavaFxTest {
         loginAsOtter(robot);
         //Click on Add Exercise
         robot.clickOn("Add Exercise");
-        robot.sleep(1000);
+        robot.sleep(400);
         //Check that name, category, and description fields show on screen
         TextField nameField = robot.lookup("#" + AddExercise.nameField).queryAs(TextField.class);
         assertNotNull(nameField, "Exercise name field should exist");
@@ -305,13 +301,65 @@ public class JavaFxTest {
         loginAsOtter(robot);
         //Click on Add Exercise
         robot.clickOn("Add Exercise");
-        robot.sleep(1000);
+        robot.sleep(400);
         //Click on cancel button
         robot.clickOn("Cancel");
-        robot.sleep(1000);
+        robot.sleep(400);
         //Should be back on MainView
         Label mainLabel = robot.lookup("Welcome, otter").queryAs(Label.class);
         assertNotNull(mainLabel, "Should return to MainView after clicking Cancel button in AddExercise");
         assertTrue(mainLabel.isVisible());
+    }
+
+    @Test
+    void addExerciseRequiresName(FxRobot robot){
+        //Login
+        loginAsOtter(robot);
+        //Click on Add Exercise
+        robot.clickOn("Add Exercise");
+        robot.sleep(400);
+        //Click on Save without anything placed in name
+        robot.clickOn("Save");
+        robot.sleep(400);
+        //Error should happen and show
+        Label error = robot.lookup("#" + AddExercise.messageField).queryAs(Label.class);
+        assertNotNull(error, "Error should appear");
+        assertFalse(error.getText().isBlank(), "Error should appear when name is blank");
+    }
+
+    @Test
+    void addExerciseDuplicate(FxRobot robot){
+        //Login
+        loginAsOtter(robot);
+        //Click on Add Exercise
+        robot.clickOn("Add Exercise");
+        robot.sleep(400);
+        //Try an already used name for an exercise
+        robot.clickOn("#" + AddExercise.nameField).write("Push-Up");
+        robot.clickOn("Save");
+        robot.sleep(400);
+        //Error for duplicate should appear
+        Label message = robot.lookup("#" + AddExercise.messageField).queryAs(Label.class);
+        assertNotNull(message, "Error message should exist");
+        assertFalse(message.getText().isBlank(), "Error message should appear for the duplicate");
+    }
+
+    @Test
+    void addExerciseSuccess(FxRobot robot){
+        //Login
+        loginAsOtter(robot);
+        //Click on Add Exercise
+        robot.clickOn("Add Exercise");
+        robot.sleep(400);
+        //Fill in New Exercise
+        robot.clickOn("#" + AddExercise.nameField).write("Plank");
+        robot.clickOn("#" + AddExercise.categoryField).write("Core");
+        robot.clickOn("#" + AddExercise.descriptionArea).write("Hold a horizontal body position");
+        //Click on Save
+        robot.clickOn("Save");
+        robot.sleep(400);
+        //Should be back on MainView after saving new exercise
+        Label mainLabel = robot.lookup("Welcome, otter").queryAs(Label.class);
+        assertNotNull(mainLabel, "Should return to MainView after clicking Save button in AddExercise");
     }
 }

--- a/src/test/java/JavaFxTest.java
+++ b/src/test/java/JavaFxTest.java
@@ -406,4 +406,17 @@ public class JavaFxTest {
         assertNotNull(title, "Delete Workout title label should exist after clicking Delete Workout");
         assertTrue(title.isVisible(), "Delete Workout title should be visible");
     }
+
+    @Test
+    void deleteWorkoutComboBoxLoads(FxRobot robot){
+        //Login
+        loginAsOtter(robot);
+        //Click on Delete Workout
+        robot.clickOn("Delete Workout");
+        robot.sleep(400);
+        //Combo Box should be loaded with Test Workouts
+        ComboBox<?> workoutCombo = robot.lookup(".combo-box").queryAs(ComboBox.class);
+        assertNotNull(workoutCombo, "Workout ComboBox should exist on Delete Workout");
+        assertFalse(workoutCombo.getItems().isEmpty(), "Workout ComboBox should contain at least one entry");
+    }
 }

--- a/src/test/java/JavaFxTest.java
+++ b/src/test/java/JavaFxTest.java
@@ -5,10 +5,8 @@ import factory.SceneType;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import javafx.scene.control.Button;
-import javafx.scene.control.Label;
-import javafx.scene.control.ListView;
-import javafx.scene.control.TextField;
+
+import javafx.scene.control.*;
 import javafx.stage.Stage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,6 +15,7 @@ import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
 import ui.login.CreateUserView;
 import ui.login.LoginView;
+import ui.main.AddExercise;
 import ui.main.ViewExercises;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -265,6 +264,54 @@ public class JavaFxTest {
         //Should be back on MainView
         Label mainLabel = robot.lookup("Welcome, otter").queryAs(Label.class);
         assertNotNull(mainLabel, "Should return to MainView after clicking Back button in ViewExercises");
+        assertTrue(mainLabel.isVisible());
+    }
+
+    @Test
+    void addExerciseOpens(FxRobot robot){
+        //Login
+        loginAsOtter(robot);
+        //Click on Add Exercise
+        robot.clickOn("Add Exercise");
+        robot.sleep(1000);
+        //Check for Title after Scene change
+        Label title = robot.lookup("Add Exercise").queryAs(Label.class);
+        assertNotNull(title, "Add Exercise title label should exist");
+        assertTrue(title.isVisible(), "Add Exercise title should be visible");
+    }
+
+    @Test
+    void addExerciseFieldsShows(FxRobot robot){
+        //Login
+        loginAsOtter(robot);
+        //Click on Add Exercise
+        robot.clickOn("Add Exercise");
+        robot.sleep(1000);
+        //Check that name, category, and description fields show on screen
+        TextField nameField = robot.lookup("#" + AddExercise.nameField).queryAs(TextField.class);
+        assertNotNull(nameField, "Exercise name field should exist");
+        assertTrue(nameField.isVisible());
+        TextField categoryField = robot.lookup("#" + AddExercise.categoryField).queryAs(TextField.class);
+        assertNotNull(categoryField, "Exercise category field should exist");
+        assertTrue(categoryField.isVisible());
+        TextArea descriptionArea = robot.lookup("#" + AddExercise.descriptionArea).queryAs(TextArea.class);
+        assertNotNull(descriptionArea, "Exercise description area should exist");
+        assertTrue(descriptionArea.isVisible());
+    }
+
+    @Test
+    void addExerciseCancelButton(FxRobot robot){
+        //Login
+        loginAsOtter(robot);
+        //Click on Add Exercise
+        robot.clickOn("Add Exercise");
+        robot.sleep(1000);
+        //Click on cancel button
+        robot.clickOn("Cancel");
+        robot.sleep(1000);
+        //Should be back on MainView
+        Label mainLabel = robot.lookup("Welcome, otter").queryAs(Label.class);
+        assertNotNull(mainLabel, "Should return to MainView after clicking Cancel button in AddExercise");
         assertTrue(mainLabel.isVisible());
     }
 }


### PR DESCRIPTION
Log Workout Tests:

Tests should be added to verify that navigating to the "Log Workout" scene displays the correct title label, confirming that the view opens successfully after login. The tests should also ensure that the "Cancel" button returns the user to the MainView, where the "Welcome, otter" label is visible, confirming proper navigation without saving any data.

---Completed

Delete Workout Tests:

Tests should be added to verify that navigating to the "Delete Workout" scene displays the correct title label and that the ComboBox is present and populated with at least one workout from the seeded test database. Additionally, tests should confirm that clicking the "Cancel" button returns the user to the MainView with the welcome label visible, ensuring correct scene transition and no unintended data modification.

---Completed

MainViewButtons Test Update:

Add Delete Workout Button exists on MainView

---Completed

View Exercises Tests:
Tests should be added to verify that navigating to the scene displays the "Exercises" title label, that the ListView is populated with at least one entry from the test database, and that the Back button returns the user to MainView with the welcome label visible.

---Completed

Add Exercise Tests
Tests should be added to verify that the scene opens and displays the "Add Exercise" title, that the name, category, and description fields are all present and visible, that submitting with a blank name shows an error message, that submitting a duplicate exercise name shows an error message, that a valid submission navigates back to MainView, and that clicking Cancel returns to MainView without saving.

---Completed